### PR TITLE
Versión 1.0.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,6 @@
 /.scrutinizer.yml           export-ignore
 /infection.json.dist        export-ignore
 /phpcs.xml.dist             export-ignore
-/phpstan.xml.dist           export-ignore
+/phpstan.neon.dist          export-ignore
 /phpunit.xml.dist           export-ignore
 /psalm.xml.dist             export-ignore

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ $consumer = new Consumer($client);
 Esta librería se mantendrá compatible con al menos la versión con
 [soporte activo de PHP](https://www.php.net/supported-versions.php) más reciente.
 
-También utilizamos [Versionado Semántico 2.0.0](docs/SEMVER.md) por lo que puedes usar esta librería
-sin temor a romper tu aplicación.
+También utilizamos [Versionado Semántico 2.0.0](docs/SEMVER.md) por lo que puedes
+usar esta librería sin temor a romper tu aplicación.
 
 ## Contribuciones
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=7.3",
         "ext-soap": "*",
-        "phpcfdi/sat-estado-cfdi": "^1.0.0"
+        "phpcfdi/sat-estado-cfdi": "^1.0.2"
     },
     "require-dev": {
         "phpcfdi/cfdi-expresiones": "^2.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,11 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
+### Version 1.0.2 2021-11-04
+
+- Se actualiza la dependencia `phpcfdi/sat-estado-cfdi:^1.0.2`.
+- Se corrige el nombre del archivo de configuración de PHPStan en los archivos excluidos del paquete de distribución.
+
 ### Version 1.0.1 2021-09-03
 
 - La versión menor de PHP es 7.3.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,8 +6,8 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios no liberados en una versión
 
-Pueden aparecer cambios no liberados que se integran a la rama principal pero no ameritan una nueva liberación de
-versión aunque sí su incorporación en la rama principal de trabajo, generalmente se tratan de cambios en el desarrollo.
+Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
+versión, aunque sí su incorporación en la rama principal de trabajo. Generalmente se tratan de cambios en el desarrollo.
 
 ## Listado de cambios
 

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -3,7 +3,7 @@
 Respetamos el estándar [Versionado Semántico 2.0.0](https://semver.org/lang/es/).
 
 En resumen, [SemVer](https://semver.org/) es un sistema de versiones de tres componentes `X.Y.Z`
-que nombraremos así: ` Breaking . Feature . Fix `, donde:
+que nombraremos ` Breaking . Feature . Fix `, donde:
 
 - `Breaking`: Rompe la compatibilidad de código con versiones anteriores.
 - `Feature`: Agrega una nueva característica que es compatible con lo anterior.
@@ -11,9 +11,9 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 
 ## Composer
 
-La herramienta [Composer](https://getcomposer.org/) es un gestor de dependencias en proyectos para PHP.
-Este gestor usa las [reglas](https://getcomposer.org/doc/articles/versions.md)
-de versionado semántico para instalar y actualizar paquetes.
+El gestor de dependencias en proyectos para PHP [Composer](https://getcomposer.org/) 
+usa las [reglas](https://getcomposer.org/doc/articles/versions.md) de versionado semántico
+para instalar y actualizar paquetes.
 
 Te recomendamos instalar dependencias de librerías (no frameworks) con *Caret Version Range*.
 Por ejemplo: `"vendor/package": "^2.5"`.
@@ -23,7 +23,7 @@ Esto significa que:
 - no debe actualizar a versiones `3.x.x`
 - no debe utilizar ninguna versión menor a `2.5.0`
 
-## Versiones 0.x.y no rompe compatibilidad
+## Versiones 0.x.y no rompen compatibilidad
 
 Las versiones que inician con cero, por ejemplo `0.y.z`, no se ajustan a las reglas de versionado.
 Se considera que estas versiones son previas a la madurez del proyecto y por lo tanto
@@ -31,9 +31,8 @@ introducen cambios sin previo aviso.
 
 ## `@internal` no rompe compatibilidad
 
-Si la librería contiene elementos marcados como `@internal` significa que no deben ser utilizados
-por tu código. Son partes de código internos de la librería.
-Por lo tanto, no se consideran breaking changes.
+Si la librería contiene elementos marcados como `@internal` significa que no deben ser utilizados por tu código.
+Son partes de código internos de la librería. Por lo tanto, no se consideran *breaking changes*.
 
 Cuando un elemento es `@internal`, dicho elemento:
 


### PR DESCRIPTION
- Se actualiza la dependencia `phpcfdi/sat-estado-cfdi:^1.0.2`.
- Se corrige el nombre del archivo de configuración de PHPStan en los archivos excluidos del paquete de distribución.
